### PR TITLE
Add Google Analytics gtag integration

### DIFF
--- a/flappy-bird.js
+++ b/flappy-bird.js
@@ -1236,6 +1236,14 @@ class FlappyBirdGame {
             this.analytics.logEvent('game_started');
         }
         
+        // Also track with Google Analytics gtag
+        if (typeof gtag !== 'undefined') {
+            gtag('event', 'game_started', {
+                event_category: 'Game',
+                event_label: 'Game Start'
+            });
+        }
+        
         // Auto-close settings when game starts
         this.hideSettings();
         
@@ -2073,6 +2081,16 @@ class FlappyBirdGame {
             });
         }
         
+        // Also track with Google Analytics gtag
+        if (typeof gtag !== 'undefined') {
+            gtag('event', 'power_up_activated', {
+                event_category: 'Power Up',
+                event_label: 'Speed Boost',
+                value: this.score,
+                custom_parameter_score: this.score
+            });
+        }
+        
         console.log('🚀 POWER-UP ACTIVATED! GOTTA GO FAST!');
         
         // Stop background music and play Sonic theme
@@ -2343,6 +2361,16 @@ class FlappyBirdGame {
             this.analytics.logEvent('game_over', {
                 score: this.score,
                 final_score: this.score
+            });
+        }
+        
+        // Also track with Google Analytics gtag
+        if (typeof gtag !== 'undefined') {
+            gtag('event', 'game_over', {
+                event_category: 'Game',
+                event_label: 'Game Over',
+                value: this.score,
+                custom_parameter_score: this.score
             });
         }
         

--- a/index.html
+++ b/index.html
@@ -5,6 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flappy X </title>
     
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1E6E1025QB"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-1E6E1025QB');
+    </script>
+    
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -224,6 +224,17 @@ class GlobalLeaderboard {
                     leaderboard_type: 'global'
                 });
                 
+                // Also track with Google Analytics gtag
+                if (typeof gtag !== 'undefined') {
+                    gtag('event', 'score_submitted', {
+                        event_category: 'Leaderboard',
+                        event_label: 'Global Score Submission',
+                        value: score,
+                        custom_parameter_score: score,
+                        custom_parameter_player: this.playerName
+                    });
+                }
+                
                 return true;
             } catch (error) {
                 console.error('❌ Failed to submit to global leaderboard:', error);


### PR DESCRIPTION
- Add Google Analytics gtag script to HTML head section
- Implement dual tracking: Firebase Analytics + Google Analytics
- Add gtag event tracking for key game events:
  - game_started: When player starts playing
  - game_over: When game ends with score value
  - power_up_activated: When speed boost is collected
  - score_submitted: When score is saved to leaderboard
- Include event categories and custom parameters
- Ensure comprehensive analytics coverage for both platforms