### PR TITLE
Replace Google Analytics with Mixpanel

### DIFF
--- a/flappy-bird.js
+++ b/flappy-bird.js
@@ -1236,12 +1236,12 @@ class FlappyBirdGame {
             this.analytics.logEvent('game_started');
         }
         
-        // Also track with Google Analytics gtag
-        if (typeof gtag !== 'undefined') {
-            gtag('event', 'game_started', {
-                event_category: 'Game',
-                event_label: 'Game Start',
-                custom_parameter_user_id: this.leaderboard.userId
+        // Also track with Mixpanel
+        if (typeof mixpanel !== 'undefined' && mixpanel.track) {
+            mixpanel.track('game_started', {
+                category: 'Game',
+                label: 'Game Start',
+                user_id: this.leaderboard.userId
             });
         }
         
@@ -2082,14 +2082,13 @@ class FlappyBirdGame {
             });
         }
         
-        // Also track with Google Analytics gtag
-        if (typeof gtag !== 'undefined') {
-            gtag('event', 'power_up_activated', {
-                event_category: 'Power Up',
-                event_label: 'Speed Boost',
-                value: this.score,
-                custom_parameter_score: this.score,
-                custom_parameter_user_id: this.leaderboard.userId
+        // Also track with Mixpanel
+        if (typeof mixpanel !== 'undefined' && mixpanel.track) {
+            mixpanel.track('power_up_activated', {
+                category: 'Power Up',
+                label: 'Speed Boost',
+                score: this.score,
+                user_id: this.leaderboard.userId
             });
         }
         
@@ -2366,14 +2365,13 @@ class FlappyBirdGame {
             });
         }
         
-        // Also track with Google Analytics gtag
-        if (typeof gtag !== 'undefined') {
-            gtag('event', 'game_over', {
-                event_category: 'Game',
-                event_label: 'Game Over',
-                value: this.score,
-                custom_parameter_score: this.score,
-                custom_parameter_user_id: this.leaderboard.userId
+        // Also track with Mixpanel
+        if (typeof mixpanel !== 'undefined' && mixpanel.track) {
+            mixpanel.track('game_over', {
+                category: 'Game',
+                label: 'Game Over',
+                score: this.score,
+                user_id: this.leaderboard.userId
             });
         }
         

--- a/index.html
+++ b/index.html
@@ -5,28 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flappy X </title>
     
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1E6E1025QB"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+    <!-- Mixpanel (replaces Google Analytics) -->
+    <script type="text/javascript">
+      (function(e,c){if(!c.__SV){var l,h;window.mixpanel=c;c._i=[];c.init=function(q,r,f){function t(d,a){var g=a.split(".");2==g.length&&(d=d[g[0]],a=g[1]);d[a]=function(){d.push([a].concat(Array.prototype.slice.call(arguments,0)))}}var b=c;"undefined"!==typeof f?b=c[f]=[]:f="mixpanel";b.people=b.people||[];b.toString=function(d){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);d||(a+=" (stub)");return a};b.people.toString=function(){return b.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders start_session_recording stop_session_recording people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+      for(h=0;h<l.length;h++)t(b,l[h]);var n="set set_once union unset remove delete".split(" ");b.get_group=function(){function d(p){a[p]=function(){b.push([g,[p].concat(Array.prototype.slice.call(arguments,0))])}}for(var a={},g=["get_group"].concat(Array.prototype.slice.call(arguments,0)),m=0;m<n.length;m++)d(n[m]);return a};c._i.push([q,r,f])};c.__SV=1.2;var k=e.createElement("script");k.type="text/javascript";k.async=!0;k.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===
+      e.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=e.getElementsByTagName("script")[0];e.parentNode.insertBefore(k,e)}})(document,window.mixpanel||[])
+      
+      mixpanel.init('f799f92a2dd5f2ca817e24ec762c5303', {
+        autocapture: false, 
+        record_sessions_percent: 0
+      })
 
-      // Get or create consistent user ID
-      let userId = localStorage.getItem('flappyUserId');
-      if (!userId) {
-        const timestamp = Date.now();
-        const random = Math.random().toString(36).substring(2, 15);
-        userId = `user_${timestamp}_${random}`;
-        localStorage.setItem('flappyUserId', userId);
-      }
-
-      gtag('config', 'G-1E6E1025QB', {
-        'user_id': userId,
-        'custom_map': {
-          'custom_parameter_user_id': 'user_id'
+      // Identify user consistently
+      ;(function(){
+        let userId = localStorage.getItem('flappyUserId');
+        if (!userId) {
+          const ts = Date.now();
+          const rand = Math.random().toString(36).substring(2, 15);
+          userId = `user_${ts}_${rand}`;
+          localStorage.setItem('flappyUserId', userId);
         }
-      });
+        mixpanel.identify(userId);
+        mixpanel.register({ user_id: userId });
+      })();
     </script>
     
     <!-- Favicon -->

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -238,15 +238,14 @@ class GlobalLeaderboard {
                     leaderboard_type: 'global'
                 });
                 
-                // Also track with Google Analytics gtag
-                if (typeof gtag !== 'undefined') {
-                    gtag('event', 'score_submitted', {
-                        event_category: 'Leaderboard',
-                        event_label: 'Global Score Submission',
-                        value: score,
-                        custom_parameter_score: score,
-                        custom_parameter_player: this.playerName,
-                        custom_parameter_user_id: this.userId
+                // Also track with Mixpanel
+                if (typeof mixpanel !== 'undefined' && mixpanel.track) {
+                    mixpanel.track('score_submitted', {
+                        category: 'Leaderboard',
+                        label: 'Global Score Submission',
+                        score: score,
+                        player: this.playerName,
+                        user_id: this.userId
                     });
                 }
                 


### PR DESCRIPTION
- Remove gtag from index.html and add Mixpanel snippet
- Identify users via persisted userId (localStorage)
- Replace gtag event calls with mixpanel.track in game and leaderboard
- Keep Firebase Realtime Database functionality intact
- No autocapture, no session recording per requirements